### PR TITLE
Fix duplicate text for used coupons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -197,9 +197,6 @@ h1 {
     color: white;
 }
 
-.used .stamp::after {
-    content: "사용됨";
-}
 
 .use-btn {
     margin-top: 1rem;
@@ -224,9 +221,6 @@ h1 {
     cursor: not-allowed;
 }
 
-.used .use-btn::after {
-    content: "사용됨";
-}
 
 .coupon-image {
     position: absolute;


### PR DESCRIPTION
## Summary
- remove ::after content for used stamps and buttons to prevent duplicate text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68590920b268832d816ed930e4e96048